### PR TITLE
fix uvicorn and httpx registering

### DIFF
--- a/src/l2sl/_parsers/httpx.py
+++ b/src/l2sl/_parsers/httpx.py
@@ -1,7 +1,10 @@
 import logging
 from typing import Any
 
+from ._core import register_builtin_parser
 
+
+@register_builtin_parser(logger="httpx")
 def httpx(event: str, record: logging.LogRecord) -> tuple[str, dict[str, Any]]:
     assert record.args is not None
     method, url, protocol, status_code, _ = record.args

--- a/src/l2sl/_parsers/uvicorn.py
+++ b/src/l2sl/_parsers/uvicorn.py
@@ -4,7 +4,7 @@ from typing import Any
 from ._core import register_builtin_parser
 from ._regexp import RegexpEventParser
 
-uvicorn_error = register_builtin_parser("uvicorn.error", RegexpEventParser())
+uvicorn_error = register_builtin_parser(RegexpEventParser(), logger="uvicorn.error")
 
 
 @uvicorn_error.register_event_handler(r"(?P<event>(Started|Finished) server process)")
@@ -25,6 +25,7 @@ def uvicorn_running(
     return groups["event"], {"host": host, "port": port}
 
 
+@register_builtin_parser(logger="uvicorn.access")
 def uvicorn_access(event: str, record: logging.LogRecord) -> tuple[str, dict[str, Any]]:
     assert record.args is not None
     origin, method, endpoint, protocol_version, status_code = record.args


### PR DESCRIPTION
Broken in #5. Also now allows for registering through a decorator for convenience.